### PR TITLE
Feature/fix race condition

### DIFF
--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -13,7 +13,6 @@ import com.malinskiy.marathon.execution.progress.ProgressReporter
 import com.malinskiy.marathon.execution.queue.QueueActor
 import com.malinskiy.marathon.execution.queue.QueueMessage
 import com.malinskiy.marathon.log.MarathonLogging
-import com.malinskiy.marathon.test.Test
 import com.malinskiy.marathon.test.TestBatch
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.SendChannel

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -101,6 +101,8 @@ class DevicePoolActor(private val poolId: DevicePoolId,
     private suspend fun executeBatch(device: DeviceInfo, batch: TestBatch) {
         devices[device.serialNumber]?.run {
             safeSend(DeviceEvent.Execute(batch))
+        } ?: run {
+            queue.send(QueueMessage.ReturnBatch(device, batch))
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/DevicePoolActor.kt
@@ -64,11 +64,11 @@ class DevicePoolActor(private val poolId: DevicePoolId,
     }
 
     private suspend fun deviceReturnedTestBatch(device: Device, batch: TestBatch) {
-        queue.send(QueueMessage.ReturnBatch(device.toDeviceInfo(), batch))
+        queue.safeSend(QueueMessage.ReturnBatch(device.toDeviceInfo(), batch))
     }
 
     private suspend fun deviceCompleted(device: Device, results: TestBatchResults) {
-        queue.send(QueueMessage.Completed(device.toDeviceInfo(), results))
+        queue.safeSend(QueueMessage.Completed(device.toDeviceInfo(), results))
     }
 
     private suspend fun deviceReady(msg: DevicePoolMessage.FromDevice.IsReady) {
@@ -101,7 +101,7 @@ class DevicePoolActor(private val poolId: DevicePoolId,
         devices[device.serialNumber]?.run {
             safeSend(DeviceEvent.Execute(batch))
         } ?: run {
-            queue.send(QueueMessage.ReturnBatch(device, batch))
+            queue.safeSend(QueueMessage.ReturnBatch(device, batch))
         }
     }
 

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -210,13 +210,11 @@ class DeviceActor(
                 device.execute(configuration, devicePoolId, batch, result, progressReporter)
             } catch (exc: TestBatchTimeoutException) {
                 logger.warn { "Timeout error during batch execution: ${exc.cause.toString()}" }
-                state.transition(DeviceEvent.Complete)
             } catch (exc: DeviceLostException) {
                 logger.error(exc) { "Critical error during batch execution: device is lost" }
                 state.transition(DeviceEvent.Terminate)
             } catch (exc: TestBatchExecutionException) {
                 logger.error(exc) { "Unknown error during batch execution: ${exc.cause.toString()}" }
-                state.transition(DeviceEvent.Complete)
             }
         }
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/device/DeviceActor.kt
@@ -209,14 +209,14 @@ class DeviceActor(
             try {
                 device.execute(configuration, devicePoolId, batch, result, progressReporter)
             } catch (exc: TestBatchTimeoutException) {
-                logger.warn { "Critical error during batch execution: batch timed out. ${exc.cause.toString()}" }
-                state.transition(DeviceEvent.Terminate)
+                logger.warn { "Timeout error during batch execution: ${exc.cause.toString()}" }
+                state.transition(DeviceEvent.Complete)
             } catch (exc: DeviceLostException) {
                 logger.error(exc) { "Critical error during batch execution: device is lost" }
                 state.transition(DeviceEvent.Terminate)
             } catch (exc: TestBatchExecutionException) {
-                logger.error(exc) { "Critical error during batch execution: ${exc.cause.toString()}" }
-                state.transition(DeviceEvent.Terminate)
+                logger.error(exc) { "Unknown error during batch execution: ${exc.cause.toString()}" }
+                state.transition(DeviceEvent.Complete)
             }
         }
     }

--- a/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
+++ b/core/src/main/kotlin/com/malinskiy/marathon/execution/queue/QueueActor.kt
@@ -85,6 +85,7 @@ class QueueActor(private val configuration: Configuration,
         }
         if (uncompleted.isNotEmpty()) {
             uncompleted.forEach {
+                testResultReporter.retryTest(device, it)
                 uncompletedTestsRetryCount[it.test] = (uncompletedTestsRetryCount[it.test] ?: 0) + 1
             }
             returnTests(uncompleted.map { it.test })

--- a/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDeviceProvider.kt
+++ b/vendor/vendor-android/src/main/kotlin/com/malinskiy/marathon/android/AndroidDeviceProvider.kt
@@ -51,7 +51,7 @@ class AndroidDeviceProvider : DeviceProvider, CoroutineScope {
             override fun deviceChanged(device: IDevice?, changeMask: Int) {
                 device?.let {
                     launch(context = bootWaitContext) {
-                        val maybeNewAndroidDevice = AndroidDevice(it)
+                        val maybeNewAndroidDevice = AndroidDevice(it, vendorConfiguration.serialStrategy)
                         val healthy = maybeNewAndroidDevice.healthy
 
                         logger.debug { "Device ${device.serialNumber} changed state. Healthy = $healthy" }
@@ -70,7 +70,7 @@ class AndroidDeviceProvider : DeviceProvider, CoroutineScope {
             override fun deviceConnected(device: IDevice?) {
                 device?.let {
                     launch {
-                        val maybeNewAndroidDevice = AndroidDevice(it)
+                        val maybeNewAndroidDevice = AndroidDevice(it, vendorConfiguration.serialStrategy)
                         val healthy = maybeNewAndroidDevice.healthy
                         logger.debug { "Device ${maybeNewAndroidDevice.serialNumber} connected. Healthy = $healthy" }
 
@@ -167,7 +167,7 @@ class AndroidDeviceProvider : DeviceProvider, CoroutineScope {
     private fun matchDdmsToDevice(device: IDevice): AndroidDevice? {
         val observedDevices = devices.values
         return observedDevices.findLast {
-            device == it.ddmsDevice ||
+            device === it.ddmsDevice ||
                     device.serialNumber == it.ddmsDevice.serialNumber
         }
     }


### PR DESCRIPTION
**Cause**:

- Device just finished running test batch and returned results to QueueActor
- Device got disconnected while the results are being processed
- QueueActor automatically sends a batch to the device
- It's disconnected so it never gets to return it's batch

**Severity**: Low. It leads to timeout issue on the build but it doesn't happen frequently.
 

**Logs**:
```
[22:42:16] : [Step 8/14] 15:42:16.278 [AndroidDevice - execution - 172.20.1.233:15001 @coroutine#87] DEBUG TestRunResultsListener - Batch test results: passed=1; failed=0; infraFailures=0; uncompleted=0; noStatus=0
[22:42:16] : [Step 8/14] 15:42:16.278 [AndroidDevice - execution - 172.20.1.233:15001 @coroutine#87] INFO DebugTestRunListener - testRunEnded elapsedTime 25266
[22:42:16] : [Step 8/14] 15:42:16.280 [main @coroutine#98] DEBUG DevicePool[omni]_DeviceActor[emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z] - Awaiting batch results to DevicePool: emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.281 [main @coroutine#98] DEBUG DevicePool[omni]_DeviceActor[emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z] - Sent batch results to DevicePool: emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.281 [main @coroutine#10] DEBUG QueueActor[DevicePoolId(name=omni)] - handle test results emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.329 [AndroidDeviceProvider-BootWait-4 @coroutine#100] DEBUG AndroidDeviceProvider - Device 172.20.1.233:15001 disconnected
[22:42:16] : [Step 8/14] 15:42:16.365 [main @coroutine#8] DEBUG Scheduler - device emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z disconnected
[22:42:16] : [Step 8/14] 15:42:16.365 [main @coroutine#10] DEBUG QueueActor[DevicePoolId(name=omni)] - request next batch for device emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.365 [main @coroutine#10] DEBUG QueueActor[DevicePoolId(name=omni)] - sending next batch for device emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.365 [main @coroutine#9] DEBUG DevicePoolActor[omni] - remove device emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z
[22:42:16] : [Step 8/14] 15:42:16.365 [main @coroutine#9] DEBUG DevicePoolActor[omni] - devices.size = 6
[22:42:16] : [Step 8/14] 15:42:16.366 [main @coroutine#102] DEBUG DevicePool[omni]_DeviceActor[emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z] - terminate emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z

...

...

...

[22:43:18] : [Step 8/14] 15:43:18.986 [main @coroutine#10] DEBUG QueueActor[DevicePoolId(name=omni)] - queue is empty but there are active batches present for emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z

...

[22:43:19] : [Step 8/14] 15:43:19.829 [main @coroutine#10] DEBUG QueueActor[DevicePoolId(name=omni)] - queue is empty but there are active batches present for emulators-emulator-provider-superrun-flights-emu-28-7cbc44x2k5z

...

EXECUTION TIMEOUT
```