### PR TITLE
Updated android sdk path

### DIFF
--- a/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
+++ b/cli/src/main/kotlin/com/malinskiy/marathon/cli/args/environment/SystemEnvironmentReader.kt
@@ -4,5 +4,5 @@ import com.malinskiy.marathon.cli.args.EnvironmentConfiguration
 import java.io.File
 
 class SystemEnvironmentReader : EnvironmentReader {
-    override fun read() = EnvironmentConfiguration(System.getenv("ANDROID_HOME")?.let { File(it) })
+    override fun read() = EnvironmentConfiguration(System.getenv("ANDROID_SDK_ROOT")?.let { File(it) })
 }

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -286,7 +286,7 @@ object ConfigFactorySpec : Spek({
         on("configuration without androidSdk value") {
             val file = File(ConfigFactorySpec::class.java.getResource("/fixture/config/sample_7.yaml").file)
 
-            it("should throw an exception when ANDROID_HOME is not set") {
+            it("should throw an exception when ANDROID_HOME_ENV is not set") {
                 val create = { parser.create(file, mockEnvironmentReader(null)) }
 
                 create shouldNotThrow ConfigurationException::class

--- a/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
+++ b/cli/src/test/kotlin/com/malinskiy/marathon/cli/config/ConfigFactorySpec.kt
@@ -286,7 +286,7 @@ object ConfigFactorySpec : Spek({
         on("configuration without androidSdk value") {
             val file = File(ConfigFactorySpec::class.java.getResource("/fixture/config/sample_7.yaml").file)
 
-            it("should throw an exception when ANDROID_HOME_ENV is not set") {
+            it("should throw an exception when ANDROID_SDK_ROOT is not set") {
                 val create = { parser.create(file, mockEnvironmentReader(null)) }
 
                 create shouldNotThrow ConfigurationException::class


### PR DESCRIPTION
Updated android SDK path variable as latest sdk deprecated ANDROID_HOME and ANDROID_SDK_ROOT is now used